### PR TITLE
Correctly set test UUIDs in tests

### DIFF
--- a/model/message_test.go
+++ b/model/message_test.go
@@ -10,8 +10,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// Values used in tests
 const (
-	// TestChannelID is the ID of the channel that the test messages are sent to
 	TestChannelID         = "000000000000000000"
 	TestMetadataUUID      = "00000000-0000-0000-0000-000000000000"
 	TestUserID            = "000000000000000000"

--- a/model/replies_test.go
+++ b/model/replies_test.go
@@ -64,11 +64,6 @@ func TestMessage_RespondToChannelOrThread(t *testing.T) {
 				err      error
 			)
 
-			// Generate a new UUID to use as the message ID for both got and want
-			// this is because the UUID is generated in the function we're testing
-			// and we don't want to have to hardcode it in the test case
-			id := uuid.NewV4()
-
 			// Execute the function we're testing
 			gotBytes, err = tt.message.RespondToChannelOrThread(tt.sourceApp, tt.content)
 
@@ -88,8 +83,8 @@ func TestMessage_RespondToChannelOrThread(t *testing.T) {
 			}
 
 			// Set the ID of the MessageSend struct to the ID we generated
-			got.Metadata.ID = id
-			tt.want.Metadata.ID = id
+			got.Metadata.ID = uuid.FromStringOrNil(TestMetadataUUID)
+			tt.want.Metadata.ID = uuid.FromStringOrNil(TestMetadataUUID)
 
 			// Compare what we got to what we want from the test case
 			if diff.Changed(got, tt.want) {


### PR DESCRIPTION
- Use `TestMetadataUUID` for a consistent UUID value across all test
- Update comments again