### PR TITLE
Fully fix outbound replies

### DIFF
--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/bytebot-chat/gateway-discord/model"
@@ -20,8 +20,13 @@ var (
 	outbound = flag.String("outbound", "discord-outbound", "Pubsub queue for sending messages outbound")
 )
 
-func main() {
+func init() {
 	flag.Parse()
+}
+
+func main() {
+
+	// An example of logging using zerolog
 	log.Info().
 		Str("version", "0.0.1").
 		Str("addr", *addr).
@@ -29,16 +34,20 @@ func main() {
 		Str("outbound", *outbound).
 		Msg("Starting pingpong")
 
-	ctx := context.Background() // Redis context
-	log.Debug().
+	// Create a new Redis client
+	ctx := context.Background() // Redis context used for all Redis operations
+	log.Info().
 		Str("address", *addr).
 		Msg("Connecting to redis")
-	rdb := redis.NewClient(&redis.Options{ // Connect to redis
-		Addr: *addr, // Redis address from command line
-		DB:   0,     // Use default DB
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr: *addr,
+		DB:   0, // use default DB
 	})
 
 	err := rdb.Ping(ctx).Err() // Ping redis to make sure it's up
+
+	// If there is an error, log it and exit
 	if err != nil {
 		log.Err(err).
 			Str("address", *addr).
@@ -53,59 +62,79 @@ func main() {
 		}
 	}
 
-	topic := rdb.Subscribe(ctx, *inbound) // Subscribe to the inbound topic
-	channel := topic.Channel()            // Create a channel to listen for messages on
-	log.Debug().
-		Str("topic", *inbound).
-		Msg("Subscribed to topic")
-	for msg := range channel { // Read messages from the channel in a loop
-		fmt.Println(msg.Payload)                    // Print the message payload
-		m := &model.Message{}                       // Create a new message
-		err := m.UnmarshalJSON([]byte(msg.Payload)) // Unmarshal the message
+	// Messages come in from a pubsub queue
+	// We need to subscribe to the queue and listen for messages
+	// We use topic.Channel() to get the channel to listen on for messages and then use a for loop to listen for messages
+	// When a message comes in, we need to parse it and then send a response
+	// We use the MessageSend struct to send the response
+	// We then use the rdb.Publish() method to send the response to the outbound queue
+
+	// Subscribe to the inbound queue
+	topic := rdb.Subscribe(ctx, *inbound)
+	channel := topic.Channel()
+
+	// Listen for messages
+	for msg := range channel {
+		log.Debug().
+			Msg("Received message")
+
+		// Create a new MessageSend struct
+		var message model.Message
+
+		// Unmarshal the message bytes into the struct
+		err := message.UnmarshalJSON([]byte(msg.Payload))
+
+		// If there is an error, log it and continue
 		if err != nil {
 			log.Err(err).
-				Str("topic", *inbound).
-				Msg("Unable to unmarshal message")
+				Msg("Unable to parse message")
+
+			// If we can't parse the message, we can't send a response
+			// So we just continue to the next message
 			continue
 		}
-		if m.Content == "ping" {
-			log.Debug().
-				Str("id", m.ID).
-				Str("source", m.Metadata.Source).
-				Str("dest", m.Metadata.Dest).
-				Str("channel", m.ChannelID).
-				Msg("Received ping")
-			reply(ctx, *m, rdb) // Reply to the message
+
+		// Check if the message is a ping
+		if !strings.HasPrefix(message.Content, "ping") {
+			// If it's not a ping, we don't need to respond
+			continue
+		}
+
+		// Log that we're sending a response
+		log.Info().
+			Msg("Ping received. Sending pong")
+
+		// Use a convenience method to create a new MessageSend struct
+		// This method takes the app name, the content of the message to send, whether to reply to the message, and whether to mention the user who sent the message
+		resp := message.RespondToChannelOrThread(APP_NAME, "Pong!", false, false)
+
+		// Debug log the response
+		log.Debug().
+			Str("message", resp.Content).
+			Str("dest", resp.Metadata.Dest).
+			Msg("Sending message")
+
+		// Marshal the struct into bytes
+		respBytes, err := resp.MarshalJSON()
+
+		// If there is an error, log it and continue
+		if err != nil {
+			log.Err(err).
+				Str("message", msg.Payload).
+				Msg("Unable to marshal message")
+			continue
+		}
+
+		// Publish the message to the outbound queue
+		err = rdb.Publish(ctx, *outbound, respBytes).Err()
+
+		// If there is an error, log it and continue
+		if err != nil {
+			log.Err(err).
+				Str("message", msg.Payload).
+				Msg("Unable to publish message")
+			continue
 		}
 	}
-}
 
-// reply replies to a message
-func reply(ctx context.Context, m model.Message, rdb *redis.Client) {
-	// Create a new message
-	// Respond in same channel, do not reply or mention the user
-	msg := m.RespondToChannelOrThread(APP_NAME, "pong", false, false)
-	msg.Content = m.Content // Set the content to the original message
-
-	// Marshal the message
-	b, err := msg.MarshalJSON()
-	if err != nil {
-		log.Err(err).
-			Str("id", m.ID).
-			Str("source", m.Metadata.Source).
-			Str("dest", m.Metadata.Dest).
-			Str("channel", m.ChannelID).
-			Msg("Unable to marshal message")
-	}
-
-	// Publish the message to the outbound topic
-	err = rdb.Publish(ctx, *outbound, b).Err()
-	if err != nil {
-		log.Err(err).
-			Str("id", m.ID).
-			Str("source", m.Metadata.Source).
-			Str("dest", m.Metadata.Dest).
-			Str("channel", m.ChannelID).
-			Msg("Unable to publish message")
-	}
 }

--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -106,7 +106,7 @@ func main() {
 
 		// Use a convenience method to create a new MessageSend struct
 		// This method takes the app name, the content of the message to send, whether to reply to the message, and whether to mention the user who sent the message
-		resp := message.RespondToChannelOrThread(APP_NAME, "Pong!", false, false)
+		resp := message.RespondToChannelOrThread(APP_NAME, "Pong with reply", true, false)
 
 		// Debug log the response
 		log.Debug().

--- a/inbound.go
+++ b/inbound.go
@@ -30,12 +30,9 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Set the metadata before sending it to Redis
 	msg.Metadata = model.Metadata{
-		Source:      *id,
-		Dest:        "",
-		ID:          uuid.NewV4(),
-		Reply:       false,
-		InReplyTo:   "",
-		MentionUser: false,
+		Source: *id,
+		Dest:   "",
+		ID:     uuid.NewV4(),
 	}
 
 	// Marshal the message to JSON

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 		Str("queue", *outbound).
 		Msg("Subscribing to outbound queue")
 
-	// Subscribe to the outbound queue
+	// Handle outbound messages in a goroutine
 	go handleOutbound(*outbound, rdb, dgo, redisCtx)
 
 	// for loop to hold the program open until CTRL-C is pressed

--- a/main.go
+++ b/main.go
@@ -120,6 +120,15 @@ func main() {
 	}
 	defer dgo.Close()
 
+	// Subscribe to the outbound queue
+	log.Info().
+		Str("func", "main").
+		Str("queue", *outbound).
+		Msg("Subscribing to outbound queue")
+
+	// Subscribe to the outbound queue
+	go handleOutbound(*outbound, rdb, dgo, redisCtx)
+
 	// for loop to hold the program open until CTRL-C is pressed
 	for {
 		select {

--- a/model/message.go
+++ b/model/message.go
@@ -15,12 +15,9 @@ type Message struct {
 
 // Metadata is used by the Gateway(s) and app(s) to trace messages and identify intended recipients
 type Metadata struct {
-	Source      string    `json:"source,omitempty"`       // Source is the ID of the Gateway or App that sent the message
-	Dest        string    `json:"dest,omitempty"`         // Dest is the ID of the Gateway or App that the message is intended for
-	ID          uuid.UUID `json:"id,omitempty"`           // ID is a UUID that is generated for each message
-	Reply       bool      `json:"reply,omitempty"`        // Reply is a boolean that indicates whether the message is a reply to another message
-	InReplyTo   string    `json:"in_reply_to,omitempty"`  // InReplyTo is the Discord ID of the message that this message is a reply to, not the metadata ID
-	MentionUser bool      `json:"mention_user,omitempty"` // MentionUser is a boolean that indicates whether the message should mention the user that sent the message
+	Source string    `json:"source,omitempty"` // Source is the ID of the Gateway or App that sent the message
+	Dest   string    `json:"dest,omitempty"`   // Dest is the ID of the Gateway or App that the message is intended for
+	ID     uuid.UUID `json:"id,omitempty"`     // ID is a UUID that is generated for each message
 }
 
 // Marhsal converts the message to JSON

--- a/model/message_test.go
+++ b/model/message_test.go
@@ -12,20 +12,20 @@ import (
 
 // Values used in tests
 const (
-	TestChannelID                = "000000000000000000"
+	TestChannelID                = "test-channel-id"
 	TestInboundMetadataUUID      = "00000000-0000-0000-0000-000000000000"
 	TestOutboundMetadataUUID     = "11111111-1111-1111-1111-111111111111"
-	TestInboundDiscordMessageID  = "222222222222222222"
-	TestOutboundDiscordMessageID = "333333333333333333"
-	TestInboundMessageBody       = "hello world"
-	TestOutboundMessageBody      = "goodbye world"
-	TestUserID                   = "000000000000000000"
-	TestUserName                 = "test-user"
+	TestInboundDiscordMessageID  = "test-inbound-discord-message-id"
+	TestOutboundDiscordMessageID = "test-outbound-discord-message-id"
+	TestInboundMessageBody       = "test-inbound-message-body"
+	TestOutboundMessageBody      = "test-outbound-message-body"
+	TestUserID                   = "test-user-id"
+	TestUserName                 = "test-user-name"
 	TestUserDiscriminator        = "0000"
-	TestMetdataSource            = "gateway"
-	TestMetdataDest              = ""
+	TestMetdataSource            = "test-source"
+	TestMetdataDest              = "test-dest"
 	TestAppName                  = "test-app"
-	TestGuildID                  = "000000000000000000"
+	TestGuildID                  = "test-guild-id"
 )
 
 func TestMessage_UnmarshalJSON(t *testing.T) {
@@ -52,16 +52,16 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 			name: "hello world",
 			messageJSON: []byte(`{
 				"metadata": {
-					"source": "gateway",
+					"source": "` + TestMetdataSource + `",
 					"dest": "",
 					"id": "00000000-0000-0000-0000-000000000000"
 				},
 				"message": {
-					"content": "hello world",
-					"channel_id": "000000000000000000",
+					"content": "` + TestInboundMessageBody + `",
+					"channel_id": "` + TestChannelID + `",
 					"author": {
-						"id": "000000000000000000",
-						"username": "test-user",
+						"id": "` + TestUserID + `",
+						"username": "` + TestUserName + `",
 						"discriminator": "0000"
 					}
 				}
@@ -161,7 +161,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 				Message: &discordgo.Message{
 					ID:              TestInboundDiscordMessageID,
 					ChannelID:       TestChannelID,
-					GuildID:         TestChannelID,
+					GuildID:         TestGuildID,
 					Content:         TestInboundMessageBody,
 					MentionRoles:    []string{},
 					MentionEveryone: false,

--- a/model/replies.go
+++ b/model/replies.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 
+	"github.com/bwmarrin/discordgo"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -10,9 +11,10 @@ import (
 // Because the discordgo.Session.ChannelMessageSend() method only accepts channel ID and content as a string, our struct limits iteslef to those two fields as well.
 // Future work may expand this to include more fields or expand metadata to include more information that can be used to forumlate more complex responses.
 type MessageSend struct {
-	ChannelID string   `json:"channel_id,omitempty"` // ChannelID is the ID of the discord channel to send the message to
-	Content   string   `json:"content,omitempty"`    // Content is the text body of the message to send
-	Metadata  Metadata `json:"metadata,omitempty"`
+	ChannelID        string                     `json:"channel_id,omitempty"`        // ChannelID is the ID of the discord channel to send the message to
+	Content          string                     `json:"content,omitempty"`           // Content is the text body of the message to send
+	Metadata         Metadata                   `json:"metadata,omitempty"`          // Metadata is the metadata that is used to track the message
+	MessageReference discordgo.MessageReference `json:"message_reference,omitempty"` // MessageReference is the message reference that is used to reply to a message
 }
 
 // Deprecated in favor of newer methods that consume the entire model.Message struct
@@ -43,6 +45,11 @@ func (m *Message) RespondToChannelOrThread(sourceApp, content string, shouldRepl
 		ChannelID: m.ChannelID,
 		Content:   content,
 		Metadata:  meta,
+		MessageReference: discordgo.MessageReference{
+			MessageID: m.ID,
+			ChannelID: m.ChannelID,
+			GuildID:   m.GuildID,
+		},
 	}
 }
 

--- a/model/replies.go
+++ b/model/replies.go
@@ -15,6 +15,8 @@ type MessageSend struct {
 	Content         string             `json:"content,omitempty"`          // Content is the text body of the message to send
 	Metadata        Metadata           `json:"metadata,omitempty"`         // Metadata is the metadata that is used to track the message
 	PreviousMessage *discordgo.Message `json:"previous_message,omitempty"` // PreviousMessage is the message that triggered this message
+	ShouldReply     bool               `json:"should_reply,omitempty"`     // ShouldReply is a flag that indicates if the message should reply to the user that sent the previous message
+	ShouldMention   bool               `json:"should_mention,omitempty"`   // ShouldMention is a flag that indicates if the message should mention the user that sent the previous message
 }
 
 // Deprecated in favor of newer methods that consume the entire model.Message struct
@@ -48,6 +50,8 @@ func (m *Message) RespondToChannelOrThread(sourceApp, content string, shouldRepl
 		Content:         content,
 		Metadata:        meta,
 		PreviousMessage: m.Message,
+		ShouldReply:     shouldReply,
+		ShouldMention:   shouldMention,
 	}
 }
 
@@ -94,6 +98,18 @@ func (m *MessageSend) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	if err := json.Unmarshal(msg["previous_message"], &m.PreviousMessage); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(msg["should_reply"], &m.ShouldReply); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(msg["should_mention"], &m.ShouldMention); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -118,6 +134,9 @@ func (m *MessageSend) MarshalJSON() ([]byte, error) {
 	msg["content"] = m.Content
 	msg["channel_id"] = m.ChannelID
 	msg["metadata"] = m.Metadata
+	msg["previous_message"] = m.PreviousMessage
+	msg["should_reply"] = m.ShouldReply
+	msg["should_mention"] = m.ShouldMention
 
 	return json.Marshal(msg)
 }

--- a/model/replies.go
+++ b/model/replies.go
@@ -33,23 +33,23 @@ func (m *Message) MarshalReply(meta Metadata, dest string, s string) ([]byte, er
 // It optionally allows the message to reply or mention the user that sent the original message
 func (m *Message) RespondToChannelOrThread(sourceApp, content string, shouldReply, shouldMention bool) *MessageSend {
 	meta := Metadata{
-		Source:      sourceApp,
-		Dest:        m.Metadata.Source,
-		ID:          uuid.NewV4(),
-		Reply:       shouldReply,
-		InReplyTo:   m.ID,
-		MentionUser: shouldMention,
+		Source: sourceApp,
+		Dest:   m.Metadata.Source,
+		ID:     uuid.NewV4(),
+	}
+	ref := discordgo.MessageReference{}
+
+	if shouldReply {
+		ref.MessageID = m.ID
+		ref.ChannelID = m.ChannelID
+		ref.GuildID = m.GuildID
 	}
 
 	return &MessageSend{
-		ChannelID: m.ChannelID,
-		Content:   content,
-		Metadata:  meta,
-		MessageReference: discordgo.MessageReference{
-			MessageID: m.ID,
-			ChannelID: m.ChannelID,
-			GuildID:   m.GuildID,
-		},
+		ChannelID:        m.ChannelID,
+		Content:          content,
+		Metadata:         meta,
+		MessageReference: ref,
 	}
 }
 

--- a/model/replies.go
+++ b/model/replies.go
@@ -11,10 +11,10 @@ import (
 // Because the discordgo.Session.ChannelMessageSend() method only accepts channel ID and content as a string, our struct limits iteslef to those two fields as well.
 // Future work may expand this to include more fields or expand metadata to include more information that can be used to forumlate more complex responses.
 type MessageSend struct {
-	ChannelID        string                     `json:"channel_id,omitempty"`        // ChannelID is the ID of the discord channel to send the message to
-	Content          string                     `json:"content,omitempty"`           // Content is the text body of the message to send
-	Metadata         Metadata                   `json:"metadata,omitempty"`          // Metadata is the metadata that is used to track the message
-	MessageReference discordgo.MessageReference `json:"message_reference,omitempty"` // MessageReference is the message reference that is used to reply to a message
+	ChannelID       string             `json:"channel_id,omitempty"`       // ChannelID is the ID of the discord channel to send the message to
+	Content         string             `json:"content,omitempty"`          // Content is the text body of the message to send
+	Metadata        Metadata           `json:"metadata,omitempty"`         // Metadata is the metadata that is used to track the message
+	PreviousMessage *discordgo.Message `json:"previous_message,omitempty"` // PreviousMessage is the message that triggered this message
 }
 
 // Deprecated in favor of newer methods that consume the entire model.Message struct
@@ -31,25 +31,23 @@ func (m *Message) MarshalReply(meta Metadata, dest string, s string) ([]byte, er
 
 // RespondToChannelOrThread generates a MessageSend struct that can be used to respond to a channel or thread
 // It optionally allows the message to reply or mention the user that sent the original message
+//
+// Typically when constructing replies you need access to the discordgo.Session but
+// applications that use this library may not have access to that object, so it actually gets handled in the gateway
+// this constraint forces the MessageSend struct to be a little bigger than I would like it to be but it's necessary
+// for now to have the correct context to respond to messages
 func (m *Message) RespondToChannelOrThread(sourceApp, content string, shouldReply, shouldMention bool) *MessageSend {
 	meta := Metadata{
 		Source: sourceApp,
 		Dest:   m.Metadata.Source,
 		ID:     uuid.NewV4(),
 	}
-	ref := discordgo.MessageReference{}
-
-	if shouldReply {
-		ref.MessageID = m.ID
-		ref.ChannelID = m.ChannelID
-		ref.GuildID = m.GuildID
-	}
 
 	return &MessageSend{
-		ChannelID:        m.ChannelID,
-		Content:          content,
-		Metadata:         meta,
-		MessageReference: ref,
+		ChannelID:       m.ChannelID,
+		Content:         content,
+		Metadata:        meta,
+		PreviousMessage: m.Message,
 	}
 }
 

--- a/model/replies_test.go
+++ b/model/replies_test.go
@@ -86,6 +86,8 @@ func TestMessage_RespondToChannelOrThread(t *testing.T) {
 					Content:   TestInboundMessageBody,
 					GuildID:   TestGuildID,
 				},
+				ShouldReply:   true,  // This should be true because we are replying to a message
+				ShouldMention: false, // This should be false because we are not mentioning the original message author
 			},
 			sourceApp:     TestAppName,
 			content:       TestOutboundMessageBody,
@@ -122,6 +124,8 @@ func TestMessage_RespondToChannelOrThread(t *testing.T) {
 					Content:   TestInboundMessageBody,
 					GuildID:   TestGuildID,
 				},
+				ShouldReply:   true, // This should be true because we are replying to a message
+				ShouldMention: true, // This should be true because we are mentioning the original message author
 			},
 			sourceApp:     TestAppName,
 			content:       TestOutboundMessageBody,

--- a/outbound.go
+++ b/outbound.go
@@ -43,16 +43,27 @@ func handleOutbound(sub string, rdb *redis.Client, s *discordgo.Session, ctx con
 				Msg("Unable to unmarshal message")
 			continue
 		}
+
 		// Send the message to Discord
-		_, err = s.ChannelMessageSend(m.ChannelID, m.Content) // TODO: Handle replies and mentions
-		if err != nil {
-			log.Err(err).
+		if m.ShouldReply {
+			log.Debug().
 				Str("func", "handleOutbound").
 				Str("id", m.Metadata.ID.String()).
-				Str("topic", sub).
-				Msg("Unable to send message to Discord")
-			continue
+				Msg("Reply requested")
+
+			_, _ = s.ChannelMessageSendReply(m.ChannelID, m.Content, m.PreviousMessage.Reference())
+		} else {
+			_, err = s.ChannelMessageSend(m.ChannelID, m.Content) // TODO: Handle replies and mentions
+			if err != nil {
+				log.Err(err).
+					Str("func", "handleOutbound").
+					Str("id", m.Metadata.ID.String()).
+					Str("topic", sub).
+					Msg("Unable to send message to Discord")
+				continue
+			}
 		}
+
 		log.Debug().
 			Str("func", "handleOutbound").
 			Str("id", m.Metadata.ID.String()).

--- a/outbound.go
+++ b/outbound.go
@@ -27,7 +27,6 @@ func handleOutbound(sub string, rdb *redis.Client, s *discordgo.Session) {
 		if err != nil {
 			log.Err(err).
 				Str("func", "handleOutbound").
-				Str("id", m.Metadata.ID.String()).
 				Str("topic", sub).
 				Msg("Unable to unmarshal message")
 			continue


### PR DESCRIPTION
I had some options here:
- Construct my own `Reference()` method on a `Message()` that would form a reply for me
- Use the existing `Reference()` method
- Construct my own `discorggo.MessageReference` to use for replies

I started with the 3rd option, but ended up going with (2) simply because it was far easier to manage the logic for outbound messages that way. Additionally, we _must_ use option 2 for future work because DM replies and mentions require direct interaction with the `discordgo.Session`, which we purposely do not expose to downstream apps. Therefore, I opted to use `ShouldReply` and `ShouldMentions` as indicators of how the outbound message is to be handled.